### PR TITLE
build: migrate coverage tooling and add PR automation

### DIFF
--- a/.claude/agents/rust-expert-standard.md
+++ b/.claude/agents/rust-expert-standard.md
@@ -245,9 +245,9 @@ cargo outdated              # Check for outdated dependencies
 cargo expand                # Expand macros
 cargo asm                   # Show assembly output
 
-# Coverage (with tarpaulin)
-cargo tarpaulin             # Generate coverage report
-cargo tarpaulin --out html  # Generate HTML coverage report
+# Coverage (with llvm-cov)
+cargo llvm-cov              # Generate coverage report
+cargo llvm-cov --html       # Generate HTML coverage report
 ```
 
 ## Resources to Reference

--- a/.claude/agents/rust-troubleshooter-advanced.md
+++ b/.claude/agents/rust-troubleshooter-advanced.md
@@ -240,7 +240,7 @@ cargo test --all-features
 cargo test --no-default-features
 cargo doc --no-deps
 cargo audit
-cargo tarpaulin --out Html
+cargo llvm-cov --html
 
 # Platform verification
 cargo test --target x86_64-pc-windows-msvc

--- a/.claude/commands/gh-pr-create.md
+++ b/.claude/commands/gh-pr-create.md
@@ -1,0 +1,91 @@
+---
+allowed-tools: Bash(git *), Bash(gh *), Read, Glob, Grep, TodoWrite
+description: Automatically create a GitHub pull request with a well-formatted title and description
+argument-hint: [ --draft ] [ --base <branch> ] [ title ] - e.g., "--draft" or "--base develop" or custom title
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Git status: !`git status --short`
+
+## Your task
+
+Create a GitHub pull request following these guidelines:
+
+1. Verify prerequisites:
+   - Check for uncommitted changes to tracked files: `git diff --quiet && git diff --cached --quiet`
+   - If there are uncommitted changes, STOP and inform the user to commit or stash them first
+   - Check that current branch is pushed to remote: `git rev-parse --abbrev-ref --symbolic-full-name @{u}`
+   - If not pushed, push with: `git push -u origin $(git branch --show-current)`
+   - Check that `gh` CLI is installed and authenticated
+
+2. Determine the base branch:
+   - If `--base <branch>` is provided in arguments, use that
+   - Otherwise, detect from remote: `git rev-parse --abbrev-ref origin/HEAD`
+   - If that fails, use "main" as default
+
+3. Parse the remaining arguments:
+   - Check for `--draft` flag to create a draft PR
+   - If a PR title is provided (after flags), use it (otherwise generate one)
+   - Arguments: $ARGUMENTS
+
+4. Gather PR information:
+   - Get commits in this PR: `git log origin/<base-branch>..HEAD --oneline`
+   - Get full diff from base: `git diff origin/<base-branch>...HEAD`
+   - Replace `<base-branch>` with the base branch determined in step 2
+
+5. Analyze all changes in the PR (NOT just the latest commit!) to determine:
+   - The primary type of change: feat, fix, docs, test, refactor, chore, build, ci, perf
+   - The scope (component/module affected)
+   - The overall purpose and impact
+
+6. Generate a PR title that:
+   - Follows conventional commit format: `type(scope): description`
+   - Uses present tense ("add" not "added")
+   - Is clear and concise (ideally < 72 characters)
+   - Accurately summarizes the entire PR, not just one commit
+
+7. Generate a PR description with this structure:
+   ```markdown
+   ## Summary
+   [2-4 bullet points summarizing what changed and why]
+
+   ## Changes
+   [Bulleted list of key changes organized by component/area]
+
+   ## Test plan
+   [Bulleted markdown checklist of steps to test the PR]
+   ```
+
+8. Create the PR:
+   - Use `gh pr create` with appropriate flags
+   - Include `--draft` if requested
+   - Include `--base <branch>` if specified
+   - Use HEREDOC for the body to ensure proper formatting:
+     ```bash
+     gh pr create --title "feat(scope): description" --body "$(cat <<'EOF'
+     ## Summary
+     ...
+     EOF
+     )"
+     ```
+
+9. Return the PR URL when successful
+
+## Examples of Usage
+
+- `/gh-pr-create` - create PR with automatic title and description
+- `/gh-pr-create --draft` - create draft PR
+- `/gh-pr-create --base develop` - create PR against develop branch
+- `/gh-pr-create --draft --base develop` - create draft PR against develop branch
+- `/gh-pr-create feat: add new feature` - create PR with custom title
+
+## Important Notes
+
+- Always check for uncommitted changes first - abort if any exist
+- Always analyze the FULL diff from base branch, not just the latest commit
+- The PR title should summarize the entire PR, considering all commits
+- Ensure the description provides clear context for reviewers
+- Test plan should be actionable and specific to the changes
+- Always verify branch is pushed before attempting to create PR

--- a/.claude/snippets/prompts/improve-test-coverage.md
+++ b/.claude/snippets/prompts/improve-test-coverage.md
@@ -39,25 +39,25 @@ cargo test --all
 
 **IMPORTANT Coverage Measurement Notes:**
 
-- Use `cargo tarpaulin` WITHOUT `--lib` flag to include integration tests for better overall coverage
-- Integration tests DO contribute to coverage when run with tarpaulin (they test the library code)
+- `cargo llvm-cov` includes all tests (integration and unit) by default for comprehensive coverage
+- Integration tests DO contribute to coverage (they test the library code)
 - Test utilities themselves (test_utils module) should be excluded from coverage metrics
-- **CRITICAL: `cargo tarpaulin` is expensive to run (takes ~3 minutes)** - save outputs to tmp files and refer back to them
+- **CRITICAL: `cargo llvm-cov` is expensive to run (takes ~3 minutes)** - save outputs to tmp files and refer back to them
 
 ```bash
 # Save baseline coverage output to a tmp file for reference (avoid re-running)
-cargo tarpaulin --out Stdout --exclude-files "*/test_utils/*" | tee /tmp/ccpm_coverage_baseline.txt
+cargo llvm-cov --ignore-filename-regex "test_utils" --text | tee /tmp/ccpm_coverage_baseline.txt
 
 # Check current coverage percentage quickly from saved file
 tail -5 /tmp/ccpm_coverage_baseline.txt
 
 # Generate HTML coverage report only when needed for detailed analysis
-cargo tarpaulin --out html --exclude-files "*/test_utils/*" --output-dir target/coverage
+cargo llvm-cov --ignore-filename-regex "test_utils" --html --output-dir target/coverage
 
 # View the HTML report (optional, for detailed analysis)
-open target/coverage/tarpaulin-report.html  # macOS
-# xdg-open target/coverage/tarpaulin-report.html  # Linux
-# start target/coverage/tarpaulin-report.html  # Windows
+open target/coverage/html/index.html  # macOS
+# xdg-open target/coverage/html/index.html  # Linux
+# start target/coverage/html/index.html  # Windows
 
 # Or use the Makefile (if available)
 make coverage
@@ -350,11 +350,11 @@ If you're within 1% of the target (e.g., at 69.91% aiming for 70%):
 1. **Measure Current State**
    ```bash
    # IMPORTANT: Save coverage output to avoid expensive re-runs
-   cargo tarpaulin --lib --out Stdout | tee /tmp/ccpm_coverage_current.txt
-   
+   cargo llvm-cov --text | tee /tmp/ccpm_coverage_current.txt
+
    # Check specific module coverage from saved output
    grep "src/module_name" /tmp/ccpm_coverage_current.txt
-   
+
    # Or reference previous runs
    cat /tmp/ccpm_coverage_*.txt | tail -1 | grep "src/module_name"
    ```
@@ -384,14 +384,14 @@ If you're within 1% of the target (e.g., at 69.91% aiming for 70%):
 5. **Measure Improvement**
    ```bash
    # Save new coverage measurement
-   cargo tarpaulin --lib --out Stdout | tee /tmp/ccpm_coverage_after_$(date +%Y%m%d_%H%M%S).txt
-   
+   cargo llvm-cov --text | tee /tmp/ccpm_coverage_after_$(date +%Y%m%d_%H%M%S).txt
+
    # Compare with previous baseline
    echo "=== Before ===" && grep "src/module_name" /tmp/ccpm_coverage_current.txt
    echo "=== After ===" && grep "src/module_name" /tmp/ccpm_coverage_after_*.txt | tail -1
-   
+
    # Generate HTML report only when needed for detailed analysis
-   # cargo tarpaulin --out html --output-dir target/coverage
+   # cargo llvm-cov --html --output-dir target/coverage
    ```
 
 6. **Commit Progress**
@@ -457,13 +457,13 @@ Track coverage improvements efficiently:
 
 ```bash
 # Save coverage runs with descriptive names
-cargo tarpaulin --lib --ignore-tests --out Stdout | tee /tmp/ccpm_coverage_no_tests.txt
+cargo llvm-cov --text --no-run | tee /tmp/ccpm_coverage_no_tests.txt
 
 # Focus on specific modules (save output)
-cargo tarpaulin --lib --out Stdout -- module_name:: | tee /tmp/ccpm_coverage_module_$(date +%Y%m%d).txt
+cargo llvm-cov --text -- module_name:: | tee /tmp/ccpm_coverage_module_$(date +%Y%m%d).txt
 
 # Skip problematic tests temporarily (save output)
-cargo tarpaulin --lib --skip 'test_name_pattern' | tee /tmp/ccpm_coverage_skip_problematic.txt
+cargo llvm-cov --text -- --skip 'test_name_pattern' | tee /tmp/ccpm_coverage_skip_problematic.txt
 
 # Compare coverage over time
 ls -la /tmp/ccpm_coverage_*.txt
@@ -511,7 +511,7 @@ Based on module importance:
 
 4. **Coverage Calculation**: Coverage percentage = (covered_lines / total_lines) × 100. Each line covered adds roughly 0.02% to a 5000-line codebase.
 
-5. **Integration vs Unit Tests**: Both contribute to coverage when using tarpaulin. Integration tests often provide broader coverage per test.
+5. **Integration vs Unit Tests**: Both contribute to coverage when using llvm-cov. Integration tests often provide broader coverage per test.
 
 ## Quick Commands Reference
 
@@ -520,13 +520,13 @@ Based on module importance:
 cargo test --all
 
 # Generate and save coverage report (EXPENSIVE - save output!)
-cargo tarpaulin --out Stdout --exclude-files "*/test_utils/*" | tee /tmp/ccpm_coverage_baseline.txt
+cargo llvm-cov --ignore-filename-regex "test_utils" --text | tee /tmp/ccpm_coverage_baseline.txt
 
 # Generate HTML report only when needed for detailed analysis
-cargo tarpaulin --out html --output-dir target/coverage
+cargo llvm-cov --ignore-filename-regex "test_utils" --html --output-dir target/coverage
 
 # Run coverage for specific module (save output)
-cargo tarpaulin --lib --out Stdout -- module_name:: | tee /tmp/ccpm_coverage_module.txt
+cargo llvm-cov --text -- module_name:: | tee /tmp/ccpm_coverage_module.txt
 
 # View saved coverage reports
 ls -la /tmp/ccpm_coverage_*.txt
@@ -542,7 +542,7 @@ cargo test -- --nocapture
 cargo test test_name -- --exact
 
 # Check coverage without running tests (save output)
-cargo tarpaulin --lib --ignore-tests --out Stdout | tee /tmp/ccpm_coverage_no_tests.txt
+cargo llvm-cov --text --no-run | tee /tmp/ccpm_coverage_no_tests.txt
 
 # Compare coverage between runs
 diff /tmp/ccpm_coverage_current.txt /tmp/ccpm_coverage_after_*.txt | tail -1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,13 +89,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install tarpaulin
+      - name: Install llvm-cov
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-tarpaulin
+          tool: cargo-llvm-cov
 
       - name: Generate coverage
-        run: cargo tarpaulin --exclude-files "*/test_utils/*" --verbose --workspace --timeout 120 --out Html
+        run: cargo llvm-cov --ignore-filename-regex "test_utils" --verbose --html
 
   build:
     name: Build Check

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ Thumbs.db
 # Coverage
 *.profraw
 *.profdata
-tarpaulin-report.html
+lcov.info
 cobertura.xml
 **/mutants.out*/
 **/mutants.out.old*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,8 +84,8 @@ When creating an issue:
    # Install cargo-nextest for faster parallel test execution
    cargo install cargo-nextest --locked
 
-   # Install cargo-tarpaulin for coverage (optional)
-   cargo install cargo-tarpaulin
+   # Install cargo-llvm-cov for coverage (optional)
+   cargo install cargo-llvm-cov
 
    # Install additional development tools
    cargo install cargo-edit  # For managing dependencies
@@ -153,7 +153,7 @@ When creating an issue:
    cargo nextest run installer
 
    # Run tests with coverage (optional)
-   cargo tarpaulin --out html --timeout 300
+   cargo llvm-cov --html
 
    # Test on different parallelism levels
    CCPM_MAX_PARALLEL=1 cargo nextest run

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,14 @@ lint:
 # Run all checks (fmt, clippy, test)
 check: fmt-check lint test
 
-# Run tests with coverage (requires cargo-tarpaulin)
+# Run tests with coverage (requires cargo-llvm-cov)
 coverage:
 	@command -v cargo-binstall >/dev/null 2>&1 || { echo "Installing cargo-binstall..."; cargo install cargo-binstall; }
-	@command -v cargo-tarpaulin >/dev/null 2>&1 || { echo "Installing cargo-tarpaulin..."; cargo binstall cargo-tarpaulin --secure; }
-	cargo tarpaulin --exclude-files "*/test_utils/*" --out html --output-dir target/coverage
+	@command -v cargo-llvm-cov >/dev/null 2>&1 || { echo "Installing cargo-llvm-cov..."; cargo binstall cargo-llvm-cov --secure; }
+	cargo llvm-cov --ignore-filename-regex "test_utils" --html --output-dir target/coverage
+	@echo ""
+	@echo "Coverage report generated at: target/coverage/html/index.html"
+	@cargo llvm-cov --ignore-filename-regex "test_utils" --summary-only
 
 # Install the binary locally
 install:

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -2250,7 +2250,7 @@ mod tests {
             .unwrap();
 
         let mut manifest = Manifest::new();
-        // Use the absolute path directly for better compatibility with tarpaulin
+        // Use the absolute path directly for better compatibility with coverage tools
         let source_url = source_dir.display().to_string();
         manifest.add_source("test".to_string(), source_url);
         manifest.add_dependency(
@@ -2376,7 +2376,7 @@ mod tests {
             .unwrap();
 
         let mut manifest = Manifest::new();
-        // Use the absolute path directly for better compatibility with tarpaulin
+        // Use the absolute path directly for better compatibility with coverage tools
         let source_url = source_dir.display().to_string();
         manifest.add_source("test".to_string(), source_url);
         manifest.add_dependency(


### PR DESCRIPTION
## Summary

- Migrated code coverage from cargo-tarpaulin to cargo-llvm-cov for better performance and reliability
- Added `/gh-pr-create` command for automated GitHub pull request creation with conventional commit formatting

## Changes

### Build & Coverage
- **CI/CD**: Updated GitHub Actions workflow to use cargo-llvm-cov instead of cargo-tarpaulin
- **Makefile**: Updated coverage target with cargo-llvm-cov, added summary output
- **Documentation**: Updated all references from tarpaulin to llvm-cov across:
  - `.gitignore` (lcov.info instead of tarpaulin-report.html)
  - `CONTRIBUTING.md` (installation and usage instructions)
  - `.claude/snippets/prompts/improve-test-coverage.md` (comprehensive coverage workflow)
  - `.claude/agents/rust-expert-standard.md` and `rust-troubleshooter-advanced.md`
- **Code comments**: Updated coverage tool references in resolver tests

### Commands
- **New command**: Added `.claude/commands/gh-pr-create.md` for automated PR creation
  - Automatically detects base branch
  - Analyzes full diff to generate conventional commit titles
  - Creates well-structured PR descriptions with summary, changes, and test plan
  - Supports `--draft` and `--base <branch>` flags

## Test plan

- [ ] Verify coverage generation works: `make coverage`
- [ ] Check HTML report is generated at `target/coverage/html/index.html`
- [ ] Verify CI passes with new llvm-cov tooling
- [ ] Test `/gh-pr-create` command creates PRs with proper formatting
- [ ] Test `/gh-pr-create --draft` creates draft PRs
- [ ] Test `/gh-pr-create --base develop` targets correct base branch